### PR TITLE
directory-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ At the root dir run the command:<br>
 ```$ mvn package```
 
 ## Run the Server
-At the root directory run the command:<br>
-```java -jar target/http-server-1.0-SNAPSHOT-jar-with-dependencies.jar```
+- Run the command below from the root directory
+- Pass in a flag and an argument for the directory to serve files from (```[-d DIRECTORY]```)
+
+Proper usage:<br>
+```$ java -jar [SERVER JAR FILE] [-d DIRECTORY]```<br>
+Example:<br>
+```$ java -jar target/http-server-1.0-SNAPSHOT-jar-with-dependencies.jar -d public```
 

--- a/src/main/java/com/bean00/ArgParser.java
+++ b/src/main/java/com/bean00/ArgParser.java
@@ -1,0 +1,26 @@
+package com.bean00;
+
+public class ArgParser {
+
+    public ServerOptions buildServerOptions(String[] args) {
+        String directory = null;
+
+        try {
+            for (int i = 0; i < args.length; i++) {
+                if (args[i].equals("-d")) {
+                    directory = args[i + 1];
+                    i++;
+                }
+            }
+        } catch (IndexOutOfBoundsException e) {
+
+        }
+
+        if (directory == null) {
+            throw new IllegalArgumentException();
+        }
+
+        return new ServerOptions(directory);
+    }
+
+}

--- a/src/main/java/com/bean00/Driver.java
+++ b/src/main/java/com/bean00/Driver.java
@@ -1,5 +1,12 @@
 package com.bean00;
 
+import com.bean00.datastore.DataStore;
+import com.bean00.datastore.FileSystemDataStore;
+import com.bean00.server.RequestParser;
+import com.bean00.server.RequestProcessor;
+import com.bean00.server.ResponseWriter;
+import com.bean00.server.Server;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -10,9 +17,21 @@ import java.net.Socket;
 public class Driver {
 
     public static void main(String[] args) throws IOException {
+        String pathToRoot;
+
+        try {
+            ArgParser argParser = new ArgParser();
+            ServerOptions options = argParser.buildServerOptions(args);
+            pathToRoot = options.getDirectory();
+        } catch (IllegalArgumentException e) {
+            printErrorMessage();
+            return;
+        }
+
         int portNumber = 5000;
-        String pathToRoot = "/Users/jonchin/8th-Light/projects/java-server/cob_spec/public";
-        System.out.println("Server started on port " + portNumber);
+        System.out.println("Server started");
+        System.out.println("- Port: " + portNumber);
+        System.out.println("- Directory: " + pathToRoot);
 
         ServerSocket serverSocket = new ServerSocket(portNumber);
         Server server = new Server();
@@ -34,6 +53,18 @@ public class Driver {
             reader.close();
             clientSocket.close();
         }
+    }
+
+    private static void printErrorMessage() {
+        System.out.print(
+                "[ERROR] Invalid arguments passed in.\n" +
+                "\n" +
+                "Proper usage:\n" +
+                "> java -jar [SERVER JAR FILE] [-d DIRECTORY]\n" +
+                "\n" +
+                "Example:\n" +
+                "> java -jar target/http-server.jar -d public\n"
+        );
     }
 
 }

--- a/src/main/java/com/bean00/ServerOptions.java
+++ b/src/main/java/com/bean00/ServerOptions.java
@@ -1,0 +1,14 @@
+package com.bean00;
+
+public class ServerOptions {
+    private String directory;
+
+    public ServerOptions(String directory) {
+        this.directory = directory;
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+
+}

--- a/src/main/java/com/bean00/datastore/DataStore.java
+++ b/src/main/java/com/bean00/datastore/DataStore.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.datastore;
 
 import java.io.IOException;
 

--- a/src/main/java/com/bean00/datastore/FileSystemDataStore.java
+++ b/src/main/java/com/bean00/datastore/FileSystemDataStore.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.datastore;
 
 import org.apache.tika.Tika;
 

--- a/src/main/java/com/bean00/httpexception/BadRequestHttpException.java
+++ b/src/main/java/com/bean00/httpexception/BadRequestHttpException.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.httpexception;
 
 public class BadRequestHttpException extends RuntimeException {
 

--- a/src/main/java/com/bean00/request/Method.java
+++ b/src/main/java/com/bean00/request/Method.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.request;
 
 public class Method {
     public static final String GET = "GET";

--- a/src/main/java/com/bean00/request/Request.java
+++ b/src/main/java/com/bean00/request/Request.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.request;
 
 import java.util.List;
 

--- a/src/main/java/com/bean00/response/Response.java
+++ b/src/main/java/com/bean00/response/Response.java
@@ -1,4 +1,6 @@
-package com.bean00;
+package com.bean00.response;
+
+import com.bean00.request.Method;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/main/java/com/bean00/response/Status.java
+++ b/src/main/java/com/bean00/response/Status.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.response;
 
 import java.util.HashMap;
 

--- a/src/main/java/com/bean00/server/RequestParser.java
+++ b/src/main/java/com/bean00/server/RequestParser.java
@@ -1,4 +1,7 @@
-package com.bean00;
+package com.bean00.server;
+
+import com.bean00.httpexception.BadRequestHttpException;
+import com.bean00.request.Request;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/main/java/com/bean00/server/RequestProcessor.java
+++ b/src/main/java/com/bean00/server/RequestProcessor.java
@@ -1,4 +1,10 @@
-package com.bean00;
+package com.bean00.server;
+
+import com.bean00.datastore.DataStore;
+import com.bean00.request.Method;
+import com.bean00.request.Request;
+import com.bean00.response.Response;
+import com.bean00.response.Status;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/main/java/com/bean00/server/ResponseWriter.java
+++ b/src/main/java/com/bean00/server/ResponseWriter.java
@@ -1,4 +1,6 @@
-package com.bean00;
+package com.bean00.server;
+
+import com.bean00.response.Response;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/main/java/com/bean00/server/Server.java
+++ b/src/main/java/com/bean00/server/Server.java
@@ -1,4 +1,9 @@
-package com.bean00;
+package com.bean00.server;
+
+import com.bean00.response.Status;
+import com.bean00.httpexception.BadRequestHttpException;
+import com.bean00.request.Request;
+import com.bean00.response.Response;
 
 import java.io.IOException;
 

--- a/src/test/java/com/bean00/ArgParserTest.java
+++ b/src/test/java/com/bean00/ArgParserTest.java
@@ -1,0 +1,78 @@
+package com.bean00;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ArgParserTest {
+
+    @Test
+    public void buildServerOptions_buildsOptionsCorrectly_ifDirectoryIsPassedIn() {
+        String expectedDirectory = "path";
+        String[] args = {"-d", "path"};
+        ArgParser parser = new ArgParser();
+
+        ServerOptions options = parser.buildServerOptions(args);
+        String directory = options.getDirectory();
+
+        assertEquals(expectedDirectory, directory);
+    }
+
+    @Test
+    public void buildServerOptions_buildsOptionsCorrectly_ifThereAreInValidFlags() {
+        String expectedDirectory = "path";
+        String[] args = {"_", "_", "-d", "path", "_", "_"};
+        ArgParser parser = new ArgParser();
+
+        ServerOptions options = parser.buildServerOptions(args);
+        String directory = options.getDirectory();
+
+        assertEquals(expectedDirectory, directory);
+    }
+
+    @Test
+    public void buildServerOptions_returnsTheSecondDirectory_ifMoreThanOneIsPassedIn() {
+        String expectedDirectory = "path2";
+        String[] args = {"-d", "path1", "-d", "path2"};
+        ArgParser parser = new ArgParser();
+
+        ServerOptions options = parser.buildServerOptions(args);
+        String directory = options.getDirectory();
+
+        assertEquals(expectedDirectory, directory);
+    }
+
+    @Test
+    public void buildServerOptions_throwsAnException_ifTheDirectoryFlagIsNotFollowedByAValue() {
+        String[] args = {"_", "-d"};
+        ArgParser parser = new ArgParser();
+
+        assertThrows(IllegalArgumentException.class, () -> parser.buildServerOptions(args));
+    }
+
+    @Test
+    public void buildServerOptions_throwsAnException_ifThereAreNotAnyValidFlags() {
+        String[] args = {"_", "_"};
+        ArgParser parser = new ArgParser();
+
+        assertThrows(IllegalArgumentException.class, () -> parser.buildServerOptions(args));
+    }
+
+    @Test
+    public void buildServerOptions_throwsAnException_ifThereIsOnlyOneArgument_andItIsNotAValidFlag() {
+        String[] args = {"_"};
+        ArgParser parser = new ArgParser();
+
+        assertThrows(IllegalArgumentException.class, () -> parser.buildServerOptions(args));
+    }
+
+    @Test
+    public void buildServerOptions_throwsAnException_ifThereAreZeroArguments() {
+        String[] args = {};
+        ArgParser parser = new ArgParser();
+
+        assertThrows(IllegalArgumentException.class, () -> parser.buildServerOptions(args));
+    }
+
+}

--- a/src/test/java/com/bean00/DriverTest.java
+++ b/src/test/java/com/bean00/DriverTest.java
@@ -1,0 +1,38 @@
+package com.bean00;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DriverTest {
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+
+    @BeforeEach
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @Test
+    public void main_printsAnErrorMessage_ifInvalidArgumentsArePassedIn() throws IOException {
+        String expectedString = "[ERROR] Invalid arguments passed in";
+        String[] args = {};
+
+        Driver.main(args);
+        String fullString = outContent.toString();
+        boolean containsExpectedString = fullString.contains(expectedString);
+
+        assertTrue(containsExpectedString);
+    }
+
+    @AfterEach
+    public void restoreStreams() {
+        System.setOut(System.out);
+    }
+
+}

--- a/src/test/java/com/bean00/datastore/FileSystemDataStoreTest.java
+++ b/src/test/java/com/bean00/datastore/FileSystemDataStoreTest.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.datastore;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/bean00/httpexception/BadRequestHttpExceptionTest.java
+++ b/src/test/java/com/bean00/httpexception/BadRequestHttpExceptionTest.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.httpexception;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/bean00/request/RequestTest.java
+++ b/src/test/java/com/bean00/request/RequestTest.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.request;
 
 public class RequestTest {
 

--- a/src/test/java/com/bean00/response/ResponseTest.java
+++ b/src/test/java/com/bean00/response/ResponseTest.java
@@ -1,5 +1,6 @@
-package com.bean00;
+package com.bean00.response;
 
+import com.bean00.request.Method;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/src/test/java/com/bean00/response/StatusTest.java
+++ b/src/test/java/com/bean00/response/StatusTest.java
@@ -1,4 +1,4 @@
-package com.bean00;
+package com.bean00.response;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/bean00/server/RequestParserTest.java
+++ b/src/test/java/com/bean00/server/RequestParserTest.java
@@ -1,5 +1,7 @@
-package com.bean00;
+package com.bean00.server;
 
+import com.bean00.httpexception.BadRequestHttpException;
+import com.bean00.request.Request;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/src/test/java/com/bean00/server/RequestProcessorTest.java
+++ b/src/test/java/com/bean00/server/RequestProcessorTest.java
@@ -1,5 +1,8 @@
-package com.bean00;
+package com.bean00.server;
 
+import com.bean00.datastore.DataStore;
+import com.bean00.request.Request;
+import com.bean00.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/bean00/server/ResponseWriterTest.java
+++ b/src/test/java/com/bean00/server/ResponseWriterTest.java
@@ -1,5 +1,7 @@
-package com.bean00;
+package com.bean00.server;
 
+import com.bean00.request.Method;
+import com.bean00.response.Response;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/com/bean00/server/ServerTest.java
+++ b/src/test/java/com/bean00/server/ServerTest.java
@@ -1,5 +1,8 @@
-package com.bean00;
+package com.bean00.server;
 
+import com.bean00.httpexception.BadRequestHttpException;
+import com.bean00.request.Request;
+import com.bean00.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
The constructor in `ArgParser` should be cleaned up. I can extract out the body into a method, and keep extracting out methods, but I also want to see if I can use some functional programming here to clean it up. Feel free to offer suggestions here.

Right now for my `DriverTest` I don't test the regular program execution (where the server just starts and runs). I tried writing that test first, but my program went into an infinite loop (due to the `while(true)`). I was considering adding an optional command-line argument that has the server run only one iteration of the loop, but I decided to just focus on testing the `IllegalArgumentException` (and leave the normal case for Cob Spec to test).